### PR TITLE
Timeout all Web3 calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rustlink"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "async-std",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ crate-type = ["cdylib", "rlib"]
 
 [package]
 name = "rustlink"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A lightweight and easy-to-use library for periodically retrieving data from the Chainlink decentralized data feed."

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     
 A lightweight rust library for periodically retrieving cryptocurrency prices from the ChainLink decentralized price feed. With `rustlink`, you can easily retrieve the latest price of any cryptocurrency supported by ChainLink. 
 
-[![crates.io](https://img.shields.io/crates/v/minismtp.svg)](https://crates.io/crates/rustlink)
+[![crates.io](https://img.shields.io/crates/v/rustlink.svg)](https://crates.io/crates/rustlink)
 [![Documentation](https://docs.rs/rustlink/badge.svg)](https://docs.rs/rustlink)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![GitHub branch status](https://img.shields.io/github/checks-status/starkbamse/rustlink/main)
@@ -34,7 +34,7 @@ To use `rustlink` in your project, add the following to your `Cargo.toml` file:
 
 ```toml
 [dependencies]
-rustlink = "0.0.2"
+rustlink = "0.0.3"
 ```
 
 ## Build for WASM

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -1,15 +1,31 @@
-use std::sync::Arc;
+use async_std::future::{timeout, TimeoutError};
+use ethers::{
+    abi::{Abi, AbiError},
+    contract::{Contract, ContractError},
+    providers::{Http, Middleware, Provider},
+    types::{Address, U256},
+};
 use serde::{Deserialize, Serialize};
-use ethers::{abi::{Abi, AbiError}, contract::Contract, providers::{Http, Provider}, types::{Address, U256}};
-
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
 
 #[derive(Clone)]
 pub struct ChainlinkContract<'a> {
     pub contract: Contract<&'a Provider<Http>>,
     pub identifier: &'a str,
     pub decimals: u8,
+    pub call_timeout: Duration,
 }
 
+#[derive(Error, Debug)]
+pub enum ContractCallError<T: Middleware> {
+    #[error("Abi error: {0}")]
+    Abi(#[from] AbiError),
+    #[error("Timeout error: {0}")]
+    Timeout(#[from] TimeoutError),
+    #[error("Contract error: {0}")]
+    Contract(#[from] ContractError<T>),
+}
 
 /// The latest price received for this symbol.
 /// This data is directly retrieved from the underlying contract.
@@ -29,6 +45,21 @@ pub struct Round {
     pub answer: f64,
 }
 
+/// Type alias for the raw round call to the contract
+pub type RoundCall<'a> = Result<(u128, u128, U256, U256, u128), ContractError<&'a Provider<Http>>>;
+
+#[allow(clippy::redundant_allocation)]
+async fn decimals<'a>(
+    contract: &ethers::contract::ContractInstance<Arc<&'a Provider<Http>>, &'a Provider<Http>>,
+) -> Result<u8, ContractError<&'a Provider<Http>>> {
+    Ok(contract
+        .method::<_, U256>("decimals", ())
+        .unwrap()
+        .call()
+        .await?
+        .as_u64() as u8)
+}
+
 impl<'a> ChainlinkContract<'a> {
     /// Creates a new instance of a chainlink price aggregator. This is just a wrapper
     /// function to simplify the interactions with the contract.
@@ -36,34 +67,34 @@ impl<'a> ChainlinkContract<'a> {
         provider: &'a Provider<Http>,
         identifier: &'a str,
         contract_address: Address,
-    ) -> Result<ChainlinkContract<'a>, AbiError> {
-        let abi:Abi=serde_json::from_str(include_str!("IAggregatorV3Interface.json")).unwrap();
-        let contract = Contract::new(contract_address, abi, Arc::new(provider));
+        call_timeout: Duration,
+    ) -> Result<ChainlinkContract<'a>, ContractCallError<&'a Provider<Http>>> {
+        let abi: Abi = serde_json::from_str(include_str!("IAggregatorV3Interface.json")).unwrap();
+        let contract: ethers::contract::ContractInstance<Arc<&Provider<Http>>, &Provider<Http>> =
+            Contract::new(contract_address, abi, Arc::new(provider));
 
-        let decimals=contract.method::<_,U256>("decimals", ()).unwrap()
-        .call().await.unwrap().as_u64() as u8;
+        let decimals = timeout(call_timeout, decimals(&contract)).await??;
 
         Ok(ChainlinkContract {
             contract,
             decimals,
             identifier,
+            call_timeout,
         })
+    }
+
+    /// Wrapper function to call the latestRoundData method on the contract
+    async fn round_data(&self) -> RoundCall<'a> {
+        let round_call: RoundCall = self.contract.method("latestRoundData", ())?.call().await;
+        round_call
     }
 
     /// Retrieves the latest price of this underlying asset
     /// from the chainlink decentralized data feed
-    pub async fn latest_round_data(&self) -> Result<Round, AbiError> {
-        let (round_id, answer, started_at, updated_at, answered_in_round): (
-            u128,
-            u128,
-            U256,
-            U256,
-            u128,
-        ) = self
-            .contract
-            .method("latestRoundData", ())?
-            .call()
-            .await.unwrap();
+    pub async fn latest_round_data(&self) -> Result<Round, ContractCallError<&'a Provider<Http>>> {
+        // Call the contract, but timeout after 10 seconds
+        let (round_id, answer, started_at, updated_at, answered_in_round) =
+            timeout(self.call_timeout, self.round_data()).await??;
 
         // Convert the answer on contract to a string.
         let float_answer: f64 = answer.to_string().parse().unwrap();
@@ -85,18 +116,22 @@ impl<'a> ChainlinkContract<'a> {
 #[cfg(test)]
 mod tests {
 
-    use ethers::{abi::Address, providers::Provider};
+    use std::time::Duration;
+
     use crate::interface::ChainlinkContract;
+    use ethers::{abi::Address, providers::Provider};
 
     #[tokio::test]
     async fn valid_answer() {
-
-        let provider=Provider::try_from("https://bsc-dataseed1.binance.org/").unwrap();
+        let provider = Provider::try_from("https://bsc-dataseed1.binance.org/").unwrap();
 
         let chainlink_contract = ChainlinkContract::new(
             &provider,
             "ETH",
-            "0x9ef1B8c0E4F7dc8bF5719Ea496883DC6401d5b2e".parse::<Address>().unwrap(),
+            "0x9ef1B8c0E4F7dc8bF5719Ea496883DC6401d5b2e"
+                .parse::<Address>()
+                .unwrap(),
+            Duration::from_secs(10),
         )
         .await
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 /// This library provides a simple interface to fetch price data from the Chainlink decentralized data feed.
 /// Core is the main module that contains the main struct `Rustlink` that you will need to interact with.
 pub mod core;
-mod interface;
 mod error;
 mod fetcher;
+mod interface;
 #[cfg(test)]
 mod tests {
 
@@ -27,6 +27,7 @@ mod tests {
             1,
             Reflector::Sender(sender),
             contracts,
+            std::time::Duration::from_secs(3),
         )
         .unwrap();
 


### PR DESCRIPTION
This PR adds a timeout functionality on all external web3 calls to ensure that they resolve within the specified time. 